### PR TITLE
Handling of requestStake forking

### DIFF
--- a/src/handlers/StakeRequestHandler.ts
+++ b/src/handlers/StakeRequestHandler.ts
@@ -45,10 +45,24 @@ export default class StakeRequestHandler extends ContractEntityHandler<StakeRequ
   /**
    * This method parse stakeRequest transaction and returns stakeRequest model object.
    *
-   * Note: In case of forking, stakeRequest transaction will be received multiple times.
-   * Check if StakeRequest record is already present in database for that stakeRequestHash. If
-   * it's present update messageHash to be NULL. This will make sure acceptStakeRequest transaction
-   * is retried again.
+   * Note: Forking Handling
+   *
+   * - Facilitator starts by subscribing to origin and auxiliary subgraphs.
+   *
+   * - On receiving first StakeRequested event/entity, entry is created in stake_requests
+   * repository and AcceptStakeRequest service is triggered.
+   *
+   * - AcceptStakeRequest sends acceptStakeRequest transaction.
+   *
+   * - If there is no forking of requestStake transaction, acceptStakeRequest transaction will be
+   * successful.
+   *
+   * - If there is forking of requestStake transaction, StakeRequested event/entity is received
+   * again. Facilitator checks the block number of new StakeRequested event. If block number is
+   * greater than stake_requests repository block number, then message hash is updated and
+   * acceptStakeRequest transaction is sent again.
+   *
+   * - acceptStakeRequest transaction is successful in this case.
    *
    * @param transactions Transaction objects.
    *

--- a/src/handlers/StakeRequestHandler.ts
+++ b/src/handlers/StakeRequestHandler.ts
@@ -97,6 +97,7 @@ export default class StakeRequestHandler extends ContractEntityHandler<StakeRequ
           } else {
             return new StakeRequest(
               stakeRequestHash,
+              blockNumber,
               amount,
               beneficiary,
               gasPrice,
@@ -105,7 +106,6 @@ export default class StakeRequestHandler extends ContractEntityHandler<StakeRequ
               gateway,
               staker,
               stakerProxy,
-              blockNumber,
             );
           }
         },

--- a/src/handlers/StakeRequestHandler.ts
+++ b/src/handlers/StakeRequestHandler.ts
@@ -78,7 +78,7 @@ export default class StakeRequestHandler extends ContractEntityHandler<StakeRequ
           if (stakeRequest && blockNumber.gt(stakeRequest.blockNumber!)) {
             Logger.debug(`stakeRequest already present for hash ${stakeRequestHash}.`);
             stakeRequest.blockNumber = blockNumber;
-            stakeRequest.messageHash = undefined;
+            stakeRequest.messageHash = null!;
             return stakeRequest;
           } else {
             return new StakeRequest(

--- a/src/models/StakeRequest.ts
+++ b/src/models/StakeRequest.ts
@@ -23,6 +23,8 @@ import Comparable from '../observer/Comparable';
 export default class StakeRequest extends Comparable<StakeRequest> {
   public stakeRequestHash: string;
 
+  public blockNumber: BigNumber;
+
   public amount?: BigNumber;
 
   public beneficiary?: string;
@@ -39,8 +41,6 @@ export default class StakeRequest extends Comparable<StakeRequest> {
 
   public stakerProxy?: string;
 
-  public blockNumber?: BigNumber;
-
   public messageHash?: string;
 
   public createdAt?: Date;
@@ -49,6 +49,7 @@ export default class StakeRequest extends Comparable<StakeRequest> {
 
   public constructor(
     stakeRequestHash: string,
+    blockNumber: BigNumber,
     amount?: BigNumber,
     beneficiary?: string,
     gasPrice?: BigNumber,
@@ -57,7 +58,6 @@ export default class StakeRequest extends Comparable<StakeRequest> {
     gateway?: string,
     staker?: string,
     stakerProxy?: string,
-    blockNumber?: BigNumber,
     messageHash?: string,
     createdAt?: Date,
     updatedAt?: Date,

--- a/src/models/StakeRequest.ts
+++ b/src/models/StakeRequest.ts
@@ -39,6 +39,8 @@ export default class StakeRequest extends Comparable<StakeRequest> {
 
   public stakerProxy?: string;
 
+  public blockNumber?: BigNumber;
+
   public messageHash?: string;
 
   public createdAt?: Date;
@@ -55,6 +57,7 @@ export default class StakeRequest extends Comparable<StakeRequest> {
     gateway?: string,
     staker?: string,
     stakerProxy?: string,
+    blockNumber?: BigNumber,
     messageHash?: string,
     createdAt?: Date,
     updatedAt?: Date,
@@ -70,6 +73,7 @@ export default class StakeRequest extends Comparable<StakeRequest> {
     this.gateway = gateway;
     this.staker = staker;
     this.stakerProxy = stakerProxy;
+    this.blockNumber = blockNumber;
     this.messageHash = messageHash;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;

--- a/src/repositories/StakeRequestRepository.ts
+++ b/src/repositories/StakeRequestRepository.ts
@@ -81,6 +81,13 @@ export default class StakeRequestRepository extends Subject<StakeRequest> {
           type: DataTypes.STRING,
           primaryKey: true,
         },
+        blockNumber: {
+          type: DataTypes.BIGINT,
+          allowNull: false,
+          validate: {
+            min: 0,
+          },
+        },
         messageHash: {
           type: DataTypes.STRING,
           allowNull: true,
@@ -129,13 +136,6 @@ export default class StakeRequestRepository extends Subject<StakeRequest> {
         stakerProxy: {
           type: DataTypes.STRING,
           allowNull: false,
-        },
-        blockNumber: {
-          type: DataTypes.BIGINT,
-          allowNull: true,
-          validate: {
-            min: 0,
-          },
         },
       },
       {

--- a/src/repositories/StakeRequestRepository.ts
+++ b/src/repositories/StakeRequestRepository.ts
@@ -241,6 +241,7 @@ export default class StakeRequestRepository extends Subject<StakeRequest> {
   private convertToStakeRequest(stakeRequestModel: StakeRequestModel): StakeRequest {
     const stakeRequest = new StakeRequest(
       stakeRequestModel.stakeRequestHash,
+      new BigNumber(stakeRequestModel.blockNumber)
     );
 
     stakeRequest.messageHash = stakeRequestModel.messageHash;
@@ -252,7 +253,6 @@ export default class StakeRequestRepository extends Subject<StakeRequest> {
     stakeRequest.gateway = stakeRequestModel.gateway;
     stakeRequest.staker = stakeRequestModel.staker;
     stakeRequest.stakerProxy = stakeRequestModel.stakerProxy;
-    stakeRequest.blockNumber = new BigNumber(stakeRequestModel.blockNumber);
     stakeRequest.createdAt = stakeRequestModel.createdAt;
     stakeRequest.updatedAt = stakeRequestModel.updatedAt;
 

--- a/src/repositories/StakeRequestRepository.ts
+++ b/src/repositories/StakeRequestRepository.ts
@@ -52,6 +52,8 @@ class StakeRequestModel extends Model {
 
   public readonly stakerProxy!: string;
 
+  public readonly blockNumber!: BigNumber;
+
   public readonly createdAt!: Date;
 
   public readonly updatedAt!: Date;
@@ -127,6 +129,13 @@ export default class StakeRequestRepository extends Subject<StakeRequest> {
         stakerProxy: {
           type: DataTypes.STRING,
           allowNull: false,
+        },
+        blockNumber: {
+          type: DataTypes.BIGINT,
+          allowNull: true,
+          validate: {
+            min: 0,
+          },
         },
       },
       {
@@ -243,6 +252,7 @@ export default class StakeRequestRepository extends Subject<StakeRequest> {
     stakeRequest.gateway = stakeRequestModel.gateway;
     stakeRequest.staker = stakeRequestModel.staker;
     stakeRequest.stakerProxy = stakeRequestModel.stakerProxy;
+    stakeRequest.blockNumber = new BigNumber(stakeRequestModel.blockNumber);
     stakeRequest.createdAt = stakeRequestModel.createdAt;
     stakeRequest.updatedAt = stakeRequestModel.updatedAt;
 

--- a/src/services/AcceptStakeRequestService.ts
+++ b/src/services/AcceptStakeRequestService.ts
@@ -122,6 +122,7 @@ export default class AcceptStakeRequestService extends Observer<StakeRequest> {
     await this.updateMessageHashInStakeRequestRepository(
       stakeRequest.stakeRequestHash,
       messageHash,
+      stakeRequest.blockNumber
     );
   }
 
@@ -232,9 +233,11 @@ export default class AcceptStakeRequestService extends Observer<StakeRequest> {
   private async updateMessageHashInStakeRequestRepository(
     stakeRequestHash: string,
     messageHash: string,
+    blockNumber: BigNumber,
   ): Promise<void> {
     const stakeRequest = new StakeRequest(
       stakeRequestHash,
+      blockNumber,
     );
     stakeRequest.messageHash = messageHash;
     Logger.debug('Updating message hash in stake request repository');

--- a/test/handlers/StakeRequestedHandler/persist.test.ts
+++ b/test/handlers/StakeRequestedHandler/persist.test.ts
@@ -114,7 +114,7 @@ describe('StakeRequestedHandler.persist()', (): void => {
       Web3Utils.toChecksumAddress(transactions2[0].staker),
       Web3Utils.toChecksumAddress(transactions2[0].stakerProxy),
       new BigNumber(transactions2[0].blockNumber),
-      undefined, // Message hash should be undefined.
+      null!, // Message hash should be null.
     );
 
     const sinonMock = sinon.createStubInstance(StakeRequestRepository, {});

--- a/test/handlers/StakeRequestedHandler/persist.test.ts
+++ b/test/handlers/StakeRequestedHandler/persist.test.ts
@@ -40,6 +40,7 @@ describe('StakeRequestedHandler.persist()', (): void => {
     const stakeRequest = new StakeRequest(
       transactions[0].stakeRequestHash,
       new BigNumber(transactions[0].amount),
+      new BigNumber(transactions[0].blockNumber),
       Web3Utils.toChecksumAddress(transactions[0].beneficiary),
       new BigNumber(transactions[0].gasPrice),
       new BigNumber(transactions[0].gasLimit),
@@ -47,7 +48,6 @@ describe('StakeRequestedHandler.persist()', (): void => {
       Web3Utils.toChecksumAddress(transactions[0].gateway),
       Web3Utils.toChecksumAddress(transactions[0].staker),
       Web3Utils.toChecksumAddress(transactions[0].stakerProxy),
-      new BigNumber(transactions[0].blockNumber),
     );
 
     assert.equal(
@@ -78,6 +78,7 @@ describe('StakeRequestedHandler.persist()', (): void => {
     }];
     const stakeRequest = new StakeRequest(
       transactions1[0].stakeRequestHash,
+      new BigNumber(transactions1[0].blockNumber),
       new BigNumber(transactions1[0].amount),
       Web3Utils.toChecksumAddress(transactions1[0].beneficiary),
       new BigNumber(transactions1[0].gasPrice),
@@ -86,7 +87,6 @@ describe('StakeRequestedHandler.persist()', (): void => {
       Web3Utils.toChecksumAddress(transactions1[0].gateway),
       Web3Utils.toChecksumAddress(transactions1[0].staker),
       Web3Utils.toChecksumAddress(transactions1[0].stakerProxy),
-      new BigNumber(transactions1[0].blockNumber),
     );
 
     // Transaction with higher block number.
@@ -106,6 +106,7 @@ describe('StakeRequestedHandler.persist()', (): void => {
 
     const stakeRequestWithNullMessageHash = new StakeRequest(
       transactions2[0].stakeRequestHash,
+      new BigNumber(transactions2[0].blockNumber),
       new BigNumber(transactions2[0].amount),
       Web3Utils.toChecksumAddress(transactions2[0].beneficiary),
       new BigNumber(transactions2[0].gasPrice),
@@ -114,7 +115,6 @@ describe('StakeRequestedHandler.persist()', (): void => {
       Web3Utils.toChecksumAddress(transactions2[0].gateway),
       Web3Utils.toChecksumAddress(transactions2[0].staker),
       Web3Utils.toChecksumAddress(transactions2[0].stakerProxy),
-      new BigNumber(transactions2[0].blockNumber),
       null!, // Message hash should be null.
     );
 

--- a/test/handlers/StakeRequestedHandler/persist.test.ts
+++ b/test/handlers/StakeRequestedHandler/persist.test.ts
@@ -9,7 +9,8 @@ import assert from '../../test_utils/assert';
 import SpyAssert from '../../test_utils/SpyAssert';
 
 describe('StakeRequestedHandler.persist()', (): void => {
-  it('should persist successfully', async (): Promise<void> => {
+  it('should persist successfully when stakeRequesteds is received first time for'
+    + ' stakeRequestHash', async (): Promise<void> => {
     const gatewayAddress = '0x0000000000000000000000000000000000000002';
     const transactions = [{
       id: '1',

--- a/test/repositories/GatewayRepository/getByChainGateway.test.ts
+++ b/test/repositories/GatewayRepository/getByChainGateway.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import BigNumber from 'bignumber.js';
 
 import Gateway from '../../../src/models/Gateway';

--- a/test/repositories/StakeRequestRepository/get.test.ts
+++ b/test/repositories/StakeRequestRepository/get.test.ts
@@ -46,6 +46,7 @@ describe('StakeRequestRepository::get', (): void => {
       'gateway',
       'staker',
       'stakerProxy',
+      new BigNumber('10'),
     );
 
     await config.repos.stakeRequestRepository.save(

--- a/test/repositories/StakeRequestRepository/get.test.ts
+++ b/test/repositories/StakeRequestRepository/get.test.ts
@@ -38,6 +38,7 @@ describe('StakeRequestRepository::get', (): void => {
   it('Checks retrieval of an existing stake request.', async (): Promise<void> => {
     const stakeRequestInput = new StakeRequest(
       'stakeRequestHash',
+      new BigNumber('10'),
       new BigNumber('1'),
       'beneficiary',
       new BigNumber('2'),
@@ -46,7 +47,6 @@ describe('StakeRequestRepository::get', (): void => {
       'gateway',
       'staker',
       'stakerProxy',
-      new BigNumber('10'),
     );
 
     await config.repos.stakeRequestRepository.save(

--- a/test/repositories/StakeRequestRepository/getWithNullMessageHash.test.ts
+++ b/test/repositories/StakeRequestRepository/getWithNullMessageHash.test.ts
@@ -41,6 +41,7 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
       repos: await Repositories.create(),
       stakeRequestWithMessageHashB: new StakeRequest(
         'stakeRequestHashB',
+        new BigNumber('10'),
         new BigNumber('11'),
         'beneficiary',
         new BigNumber('12'),
@@ -49,11 +50,11 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
         'gateway',
         'stakerB',
         'stakerProxyB',
-        new BigNumber('10'),
         'messageHashB',
       ),
       stakeRequestWithNullMessageHashC: new StakeRequest(
         'stakeRequestHashC',
+        new BigNumber('10'),
         new BigNumber('21'),
         'beneficiaryC',
         new BigNumber('22'),
@@ -62,10 +63,10 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
         'gatewayC',
         'stakerC',
         'stakerC',
-        new BigNumber('10'),
       ),
       stakeRequestWithNullMessageHashD: new StakeRequest(
         'stakeRequestHashD',
+        new BigNumber('10'),
         new BigNumber('31'),
         'beneficiary',
         new BigNumber('32'),
@@ -74,7 +75,6 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
         'gatewayD',
         'stakerD',
         'stakerD',
-        new BigNumber('10'),
       ),
     };
 

--- a/test/repositories/StakeRequestRepository/getWithNullMessageHash.test.ts
+++ b/test/repositories/StakeRequestRepository/getWithNullMessageHash.test.ts
@@ -49,6 +49,7 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
         'gateway',
         'stakerB',
         'stakerProxyB',
+        new BigNumber('10'),
         'messageHashB',
       ),
       stakeRequestWithNullMessageHashC: new StakeRequest(
@@ -61,6 +62,7 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
         'gatewayC',
         'stakerC',
         'stakerC',
+        new BigNumber('10'),
       ),
       stakeRequestWithNullMessageHashD: new StakeRequest(
         'stakeRequestHashD',
@@ -72,6 +74,7 @@ describe('StakeRequestRepository::getWithNullMessageHash', (): void => {
         'gatewayD',
         'stakerD',
         'stakerD',
+        new BigNumber('10'),
       ),
     };
 

--- a/test/repositories/StakeRequestRepository/save.test.ts
+++ b/test/repositories/StakeRequestRepository/save.test.ts
@@ -46,6 +46,7 @@ describe('StakeRequestRepository::save', (): void => {
       'gateway',
       'staker',
       'stakerProxy',
+      new BigNumber('10'),
     );
 
     const stakeRequestResponse = await config.repos.stakeRequestRepository.save(
@@ -84,6 +85,7 @@ describe('StakeRequestRepository::save', (): void => {
       'gateway',
       'staker',
       'stakerProxy',
+      new BigNumber('10'),
     );
 
     await config.repos.stakeRequestRepository.save(
@@ -111,6 +113,7 @@ describe('StakeRequestRepository::save', (): void => {
         stakeRequestUpdateInput.gateway,
         stakeRequestUpdateInput.staker,
         stakeRequestUpdateInput.stakerProxy,
+        new BigNumber('10'),
         stakeRequestInput.messageHash,
       ),
       stakeRequestResponse,
@@ -137,6 +140,7 @@ describe('StakeRequestRepository::save', (): void => {
         stakeRequestUpdateInput.gateway,
         stakeRequestUpdateInput.staker,
         stakeRequestUpdateInput.stakerProxy,
+        new BigNumber('10'),
         stakeRequestInput.messageHash,
       ),
       stakeRequestOutput as StakeRequest,

--- a/test/repositories/StakeRequestRepository/save.test.ts
+++ b/test/repositories/StakeRequestRepository/save.test.ts
@@ -38,6 +38,7 @@ describe('StakeRequestRepository::save', (): void => {
   it('Checks creation.', async (): Promise<void> => {
     const stakeRequestInput = new StakeRequest(
       'stakeRequestHash',
+      new BigNumber('10'),
       new BigNumber('1'),
       'beneficiary',
       new BigNumber('2'),
@@ -46,7 +47,6 @@ describe('StakeRequestRepository::save', (): void => {
       'gateway',
       'staker',
       'stakerProxy',
-      new BigNumber('10'),
     );
 
     const stakeRequestResponse = await config.repos.stakeRequestRepository.save(
@@ -77,6 +77,7 @@ describe('StakeRequestRepository::save', (): void => {
   it('Checks update.', async (): Promise<void> => {
     const stakeRequestInput = new StakeRequest(
       'stakeRequestHash',
+      new BigNumber('10'),
       new BigNumber('1'),
       'beneficiary',
       new BigNumber('2'),
@@ -85,7 +86,6 @@ describe('StakeRequestRepository::save', (): void => {
       'gateway',
       'staker',
       'stakerProxy',
-      new BigNumber('10'),
     );
 
     await config.repos.stakeRequestRepository.save(
@@ -94,6 +94,7 @@ describe('StakeRequestRepository::save', (): void => {
 
     const stakeRequestUpdateInput = new StakeRequest(
       'stakeRequestHash',
+      stakeRequestInput.blockNumber,
     );
     stakeRequestUpdateInput.amount = new BigNumber('11');
     stakeRequestUpdateInput.gateway = 'gatewayUpdated';
@@ -105,6 +106,7 @@ describe('StakeRequestRepository::save', (): void => {
     Util.checkInputAgainstOutput(
       new StakeRequest(
         stakeRequestInput.stakeRequestHash,
+        stakeRequestInput.blockNumber,
         stakeRequestUpdateInput.amount,
         stakeRequestInput.beneficiary,
         stakeRequestInput.gasPrice,
@@ -113,7 +115,6 @@ describe('StakeRequestRepository::save', (): void => {
         stakeRequestUpdateInput.gateway,
         stakeRequestUpdateInput.staker,
         stakeRequestUpdateInput.stakerProxy,
-        new BigNumber('10'),
         stakeRequestInput.messageHash,
       ),
       stakeRequestResponse,
@@ -132,6 +133,7 @@ describe('StakeRequestRepository::save', (): void => {
     Util.checkInputAgainstOutput(
       new StakeRequest(
         stakeRequestInput.stakeRequestHash,
+        stakeRequestInput.blockNumber,
         stakeRequestUpdateInput.amount,
         stakeRequestInput.beneficiary,
         stakeRequestInput.gasPrice,
@@ -140,7 +142,6 @@ describe('StakeRequestRepository::save', (): void => {
         stakeRequestUpdateInput.gateway,
         stakeRequestUpdateInput.staker,
         stakeRequestUpdateInput.stakerProxy,
-        new BigNumber('10'),
         stakeRequestInput.messageHash,
       ),
       stakeRequestOutput as StakeRequest,

--- a/test/repositories/StakeRequestRepository/util.ts
+++ b/test/repositories/StakeRequestRepository/util.ts
@@ -90,6 +90,13 @@ const Util = {
       );
     }
 
+    if (stakeRequestInput.blockNumber !== undefined) {
+      assert.deepStrictEqual(
+        stakeRequestInput.blockNumber,
+        stakeRequestOutput.blockNumber,
+      );
+    }
+
     if (stakeRequestInput.createdAt !== undefined) {
       assert.strictEqual(
         stakeRequestInput.createdAt,

--- a/test/services/AcceptStakeRequestService/update.test.ts
+++ b/test/services/AcceptStakeRequestService/update.test.ts
@@ -80,6 +80,7 @@ describe('AcceptStakeRequestService::update', (): void => {
         '0x0000000000000000000000000000000000000002',
         '0x0000000000000000000000000000000000000003',
         '0x0000000000000000000000000000000000000004',
+        new BigNumber('10'),
         'messageHashB',
       ),
       stakeRequestWithNullMessageHashC: new StakeRequest(
@@ -92,6 +93,7 @@ describe('AcceptStakeRequestService::update', (): void => {
         '0x0000000000000000000000000000000000000012',
         '0x0000000000000000000000000000000000000013',
         '0x0000000000000000000000000000000000000014',
+        new BigNumber('10'),
       ),
       service,
       fakeData: {

--- a/test/services/AcceptStakeRequestService/update.test.ts
+++ b/test/services/AcceptStakeRequestService/update.test.ts
@@ -72,6 +72,7 @@ describe('AcceptStakeRequestService::update', (): void => {
       repos,
       stakeRequestWithMessageHashB: new StakeRequest(
         'stakeRequestHashB',
+        new BigNumber('10'),
         new BigNumber('11'),
         '0x0000000000000000000000000000000000000001',
         new BigNumber('12'),
@@ -80,11 +81,11 @@ describe('AcceptStakeRequestService::update', (): void => {
         '0x0000000000000000000000000000000000000002',
         '0x0000000000000000000000000000000000000003',
         '0x0000000000000000000000000000000000000004',
-        new BigNumber('10'),
         'messageHashB',
       ),
       stakeRequestWithNullMessageHashC: new StakeRequest(
         'stakeRequestHashC',
+        new BigNumber('10'),
         new BigNumber('21'),
         '0x0000000000000000000000000000000000000011',
         new BigNumber('22'),
@@ -93,7 +94,6 @@ describe('AcceptStakeRequestService::update', (): void => {
         '0x0000000000000000000000000000000000000012',
         '0x0000000000000000000000000000000000000013',
         '0x0000000000000000000000000000000000000014',
-        new BigNumber('10'),
       ),
       service,
       fakeData: {

--- a/test/test_utils/StubData.ts
+++ b/test/test_utils/StubData.ts
@@ -22,6 +22,7 @@ export default class StubData {
     'gateway',
     'staker',
     'stakerProxy',
+    new BigNumber('10'),
   );
 
   public static auxiliaryChainRecord(

--- a/test/test_utils/StubData.ts
+++ b/test/test_utils/StubData.ts
@@ -14,6 +14,7 @@ import {
 export default class StubData {
   public static getAStakeRequest = (stakeRequestHash: string): StakeRequest => new StakeRequest(
     stakeRequestHash,
+    new BigNumber('10'),
     new BigNumber('1'),
     'beneficiary',
     new BigNumber('2'),
@@ -22,7 +23,6 @@ export default class StubData {
     'gateway',
     'staker',
     'stakerProxy',
-    new BigNumber('10'),
   );
 
   public static auxiliaryChainRecord(


### PR DESCRIPTION
Forking issue is observed on goerli quite frequently for stakeRequest transaction. This is causing acceptStakeRequest transactions to fail.

**Transaction History**

**StakeRequest First Transaction** https://goerli.etherscan.io/tx/0x78df824e72837a0f5793656072b1e6a8730398aefbdac3ebdb71f5266ec96545
**Mined Block**
https://goerli.etherscan.io/block/1089455

**StakeRequest Second Transaction** https://goerli.etherscan.io/tx/0x78df824e72837a0f5793656072b1e6a8730398aefbdac3ebdb71f5266ec96545
**Mined Block with failure of acceptStakeRequest and StakeRequest transaction**
https://goerli.etherscan.io/txs?block=1089456

Fixes #167 
