### PR TITLE
Make repository and model fields names generic(non-ost)

### DIFF
--- a/src/models/AuxiliaryChain.ts
+++ b/src/models/AuxiliaryChain.ts
@@ -27,9 +27,9 @@ export default class AuxiliaryChain extends Comparable<AuxiliaryChain> {
 
   public originChainName: string;
 
-  public ostGatewayAddress: string;
+  public eip20GatewayAddress: string;
 
-  public ostCoGatewayAddress: string;
+  public eip20CoGatewayAddress: string;
 
   public anchorAddress: string;
 
@@ -48,8 +48,8 @@ export default class AuxiliaryChain extends Comparable<AuxiliaryChain> {
    *
    * @param chainId Chain identifier.
    * @param originChainName Name of the origin chain.
-   * @param ostGatewayAddress Gateway contract address.
-   * @param ostCoGatewayAddress CoGateway contract address.
+   * @param eip20GatewayAddress Gateway contract address.
+   * @param eip20CoGatewayAddress CoGateway contract address.
    * @param anchorAddress Anchor contract address.
    * @param coAnchorAddress CoAnchor contract address.
    * @param lastOriginBlockHeight Latest origin chain block height.
@@ -60,8 +60,8 @@ export default class AuxiliaryChain extends Comparable<AuxiliaryChain> {
   public constructor(
     chainId: number,
     originChainName: string,
-    ostGatewayAddress: string,
-    ostCoGatewayAddress: string,
+    eip20GatewayAddress: string,
+    eip20CoGatewayAddress: string,
     anchorAddress: string,
     coAnchorAddress: string,
     lastOriginBlockHeight?: BigNumber,
@@ -72,8 +72,8 @@ export default class AuxiliaryChain extends Comparable<AuxiliaryChain> {
     super();
     this.chainId = chainId;
     this.originChainName = originChainName;
-    this.ostGatewayAddress = ostGatewayAddress;
-    this.ostCoGatewayAddress = ostCoGatewayAddress;
+    this.eip20GatewayAddress = eip20GatewayAddress;
+    this.eip20CoGatewayAddress = eip20CoGatewayAddress;
     this.anchorAddress = anchorAddress;
     this.coAnchorAddress = coAnchorAddress;
     this.lastOriginBlockHeight = lastOriginBlockHeight;

--- a/src/repositories/AuxiliaryChainRepository.ts
+++ b/src/repositories/AuxiliaryChainRepository.ts
@@ -31,9 +31,9 @@ class AuxiliaryChainModel extends Model {
 
   public readonly originChainName!: string;
 
-  public readonly ostGatewayAddress!: string;
+  public readonly eip20GatewayAddress!: string;
 
-  public readonly ostCoGatewayAddress!: string;
+  public readonly eip20CoGatewayAddress!: string;
 
   public readonly anchorAddress!: string;
 
@@ -74,7 +74,7 @@ export default class AuxiliaryChainRepository extends Subject<AuxiliaryChain> {
             len: [3, 50],
           },
         },
-        ostGatewayAddress: {
+        eip20GatewayAddress: {
           type: DataTypes.STRING,
           allowNull: false,
           validate: {
@@ -82,7 +82,7 @@ export default class AuxiliaryChainRepository extends Subject<AuxiliaryChain> {
             len: [42, 42],
           },
         },
-        ostCoGatewayAddress: {
+        eip20CoGatewayAddress: {
           type: DataTypes.STRING,
           allowNull: false,
           validate: {
@@ -214,8 +214,8 @@ export default class AuxiliaryChainRepository extends Subject<AuxiliaryChain> {
     return new AuxiliaryChain(
       auxiliaryChainModel.chainId,
       auxiliaryChainModel.originChainName,
-      auxiliaryChainModel.ostGatewayAddress,
-      auxiliaryChainModel.ostCoGatewayAddress,
+      auxiliaryChainModel.eip20GatewayAddress,
+      auxiliaryChainModel.eip20CoGatewayAddress,
       auxiliaryChainModel.anchorAddress,
       auxiliaryChainModel.coAnchorAddress,
       new BigNumber(auxiliaryChainModel.lastOriginBlockHeight),

--- a/src/services/redeem_and_unstake/ProveCoGatewayService.ts
+++ b/src/services/redeem_and_unstake/ProveCoGatewayService.ts
@@ -163,7 +163,7 @@ export default class ProveCoGatewayService extends Observer<AuxiliaryChain> {
   /**
    * This is a private method which uses mosaic.js to make proveGateway transaction.
    *
-   * @param gatewayAddress  ost gateway address in origin chain.
+   * @param gatewayAddress  Gateway address in origin chain.
    * @param lastOriginBlockHeight Block height at which latest state root is anchored.
    * @param encodedAccountValue RPL encoded value of gateway account.
    * @param serializedAccountProof RLP encoded value of account proof.

--- a/src/services/stake_and_mint/ProveGatewayService.ts
+++ b/src/services/stake_and_mint/ProveGatewayService.ts
@@ -168,7 +168,7 @@ export default class ProveGatewayService extends Observer<AuxiliaryChain> {
   /**
    * This is a private method which uses mosaic.js to make proveGateway transaction.
    *
-   * @param ostCoGatewayAddress  ost co-gateway address.
+   * @param eip20CoGatewayAddress  Gateway address in auxiliary chain.
    * @param lastOriginBlockHeight Block height at which latest state root is anchored.
    * @param encodedAccountValue RPL encoded value of gateway account.
    * @param serializedAccountProof RLP encoded value of account proof.
@@ -176,14 +176,14 @@ export default class ProveGatewayService extends Observer<AuxiliaryChain> {
    * @return Return a promise that resolves to receipt.
    */
   private async prove(
-    ostCoGatewayAddress: string,
+    eip20CoGatewayAddress: string,
     lastOriginBlockHeight: BigNumber,
     encodedAccountValue: string,
     serializedAccountProof: string,
   ): Promise<string> {
     const eip20CoGateway: EIP20CoGateway = interacts.getEIP20CoGateway(
       this.auxiliaryWeb3,
-      ostCoGatewayAddress,
+      eip20CoGatewayAddress,
     );
 
     const transactionOptions = {

--- a/test/repositories/AuxiliaryChainRepository/get.test.ts
+++ b/test/repositories/AuxiliaryChainRepository/get.test.ts
@@ -37,8 +37,8 @@ describe('AuxiliaryChain::get', (): void => {
     };
     const chainId = 2;
     const originChainName = 'ropsten';
-    const ostGatewayAddress = '0x0000000000000000000000000000000000000001';
-    const ostCoGatewayAddress = '0x0000000000000000000000000000000000000002';
+    const eip20GatewayAddress = '0x0000000000000000000000000000000000000001';
+    const eip20CoGatewayAddress = '0x0000000000000000000000000000000000000002';
     const anchorAddress = '0x0000000000000000000000000000000000000003';
     const coAnchorAddress = '0x0000000000000000000000000000000000000004';
     const lastOriginBlockHeight = new BigNumber('200');
@@ -49,8 +49,8 @@ describe('AuxiliaryChain::get', (): void => {
     auxiliaryChain = new AuxiliaryChain(
       chainId,
       originChainName,
-      ostGatewayAddress,
-      ostCoGatewayAddress,
+      eip20GatewayAddress,
+      eip20CoGatewayAddress,
       anchorAddress,
       coAnchorAddress,
       lastOriginBlockHeight,

--- a/test/repositories/AuxiliaryChainRepository/save.test.ts
+++ b/test/repositories/AuxiliaryChainRepository/save.test.ts
@@ -102,7 +102,7 @@ describe('AuxiliaryChainRepository::save', (): void => {
     Util.assertAuxiliaryChainAttributes(updatedAuxiliaryChain, auxiliaryChain);
   });
 
-  it('should fail when ostGatewayAddress is null', async (): Promise<void> => {
+  it('should fail when eip20GatewayAddress is null', async (): Promise<void> => {
     const auxiliaryChain = new AuxiliaryChain(
       chainId,
       originChainName,
@@ -119,10 +119,10 @@ describe('AuxiliaryChainRepository::save', (): void => {
     assert.isRejected(config.repos.auxiliaryChainRepository.save(
       auxiliaryChain,
     ),
-    'AuxiliaryChain.ostGatewayAddress cannot be null');
+    'AuxiliaryChain.eip20GatewayAddress cannot be null');
   });
 
-  it('should fail when ostGatewayAddress is undefined', async (): Promise<void> => {
+  it('should fail when eip20GatewayAddress is undefined', async (): Promise<void> => {
     const auxiliaryChain = new AuxiliaryChain(
       chainId,
       originChainName,
@@ -140,7 +140,7 @@ describe('AuxiliaryChainRepository::save', (): void => {
       config.repos.auxiliaryChainRepository.save(
         auxiliaryChain,
       ),
-      'AuxiliaryChain.ostGatewayAddress cannot be null',
+      'AuxiliaryChain.eip20GatewayAddress cannot be null',
     );
   });
 
@@ -172,8 +172,8 @@ describe('AuxiliaryChainRepository::save', (): void => {
     } catch (error) {
       assertErrorMessages(error.errors, [
         'AuxiliaryChain.originChainName cannot be null',
-        'Validation len on ostGatewayAddress failed',
-        'Validation len on ostCoGatewayAddress failed',
+        'Validation len on eip20GatewayAddress failed',
+        'Validation len on eip20CoGatewayAddress failed',
         'Validation len on anchorAddress failed',
         'Validation len on coAnchorAddress failed',
       ]);

--- a/test/repositories/AuxiliaryChainRepository/save.test.ts
+++ b/test/repositories/AuxiliaryChainRepository/save.test.ts
@@ -31,8 +31,8 @@ let config: TestConfigInterface;
 describe('AuxiliaryChainRepository::save', (): void => {
   let chainId: number;
   let originChainName: string;
-  let ostGatewayAddress: string;
-  let ostCoGatewayAddress: string;
+  let eip20GatewayAddress: string;
+  let eip20CoGatewayAddress: string;
   let anchorAddress: string;
   let coAnchorAddress: string;
   let lastOriginBlockHeight: BigNumber;
@@ -46,8 +46,8 @@ describe('AuxiliaryChainRepository::save', (): void => {
     };
     chainId = 2;
     originChainName = 'ropsten';
-    ostGatewayAddress = '0x0000000000000000000000000000000000000001';
-    ostCoGatewayAddress = '0x0000000000000000000000000000000000000002';
+    eip20GatewayAddress = '0x0000000000000000000000000000000000000001';
+    eip20CoGatewayAddress = '0x0000000000000000000000000000000000000002';
     anchorAddress = '0x0000000000000000000000000000000000000003';
     coAnchorAddress = '0x0000000000000000000000000000000000000004';
     lastOriginBlockHeight = new BigNumber('200');
@@ -60,8 +60,8 @@ describe('AuxiliaryChainRepository::save', (): void => {
     const auxiliaryChain = new AuxiliaryChain(
       chainId,
       originChainName,
-      ostGatewayAddress,
-      ostCoGatewayAddress,
+      eip20GatewayAddress,
+      eip20CoGatewayAddress,
       anchorAddress,
       coAnchorAddress,
       lastOriginBlockHeight,
@@ -80,8 +80,8 @@ describe('AuxiliaryChainRepository::save', (): void => {
     const auxiliaryChain = new AuxiliaryChain(
       chainId,
       originChainName,
-      ostGatewayAddress,
-      ostCoGatewayAddress,
+      eip20GatewayAddress,
+      eip20CoGatewayAddress,
       anchorAddress,
       coAnchorAddress,
       lastOriginBlockHeight,
@@ -107,7 +107,7 @@ describe('AuxiliaryChainRepository::save', (): void => {
       chainId,
       originChainName,
       null as any,
-      ostCoGatewayAddress,
+      eip20CoGatewayAddress,
       anchorAddress,
       coAnchorAddress,
       lastOriginBlockHeight,
@@ -127,7 +127,7 @@ describe('AuxiliaryChainRepository::save', (): void => {
       chainId,
       originChainName,
       undefined as any,
-      ostCoGatewayAddress,
+      eip20CoGatewayAddress,
       anchorAddress,
       coAnchorAddress,
       lastOriginBlockHeight,

--- a/test/repositories/AuxiliaryChainRepository/util.ts
+++ b/test/repositories/AuxiliaryChainRepository/util.ts
@@ -36,15 +36,15 @@ const Util = {
     );
 
     assert.strictEqual(
-      inputAuxiliaryChain.ostGatewayAddress,
-      expectedAuxiliaryChain.ostGatewayAddress,
-      'ostGatewayAddress should match',
+      inputAuxiliaryChain.eip20GatewayAddress,
+      expectedAuxiliaryChain.eip20GatewayAddress,
+      'eip20GatewayAddress should match',
     );
 
     assert.strictEqual(
-      inputAuxiliaryChain.ostCoGatewayAddress,
-      expectedAuxiliaryChain.ostCoGatewayAddress,
-      'ostCoGatewayAddress should match',
+      inputAuxiliaryChain.eip20CoGatewayAddress,
+      expectedAuxiliaryChain.eip20CoGatewayAddress,
+      'eip20CoGatewayAddress should match',
     );
 
     assert.strictEqual(

--- a/test_integration/Utils.ts
+++ b/test_integration/Utils.ts
@@ -676,14 +676,14 @@ export default class Utils {
     );
 
     assert.strictEqual(
-      actualAuxiliaryChain.ostGatewayAddress,
-      expectedAuxiliaryChain.ostGatewayAddress,
+      actualAuxiliaryChain.eip20GatewayAddress,
+      expectedAuxiliaryChain.eip20GatewayAddress,
       'Incorrect gateway address',
     );
 
     assert.strictEqual(
-      actualAuxiliaryChain.ostCoGatewayAddress,
-      expectedAuxiliaryChain.ostCoGatewayAddress,
+      actualAuxiliaryChain.eip20CoGatewayAddress,
+      expectedAuxiliaryChain.eip20CoGatewayAddress,
       'Incorrect ost cogateway address',
     );
 


### PR DESCRIPTION
PR contains changes to rename field names to generic in model, repository and unit test cases.
fixes #233 