### PR TITLE
Display exporting of worker keys on terminal in faciltiator init

### DIFF
--- a/src/bin/facilitator-init.ts
+++ b/src/bin/facilitator-init.ts
@@ -192,8 +192,8 @@ commander
 
     Logger.info(`👉 worker address for ${auxChainId} chain is `
       + `${facilitatorConfig.chains[auxChainId].worker}`);
-    Logger.info(`ℹ️ Run below two commands on terminal by replacing <origin password> and <auxiliary-password> with origin and auxiliary password entered in command`);
-    Logger.info(`1. export ${ENV_WORKER_PASSWORD_PREFIX + facilitatorConfig.chains[originChainId].worker}=<origin-password>`);
-    Logger.info(`2. export ${ENV_WORKER_PASSWORD_PREFIX + facilitatorConfig.chains[auxChainId].worker}=<auxiliary-password>`);
+    Logger.info(`\nℹ️  Run below two commands on terminal by replacing <origin password> and <auxiliary-password> with origin and auxiliary password entered in command. \n
+        1. export ${ENV_WORKER_PASSWORD_PREFIX + facilitatorConfig.chains[originChainId].worker}=<origin-password>
+        2. export ${ENV_WORKER_PASSWORD_PREFIX + facilitatorConfig.chains[auxChainId].worker}=<auxiliary-password> \n\n`);
   })
   .parse(process.argv);

--- a/src/bin/facilitator-init.ts
+++ b/src/bin/facilitator-init.ts
@@ -192,5 +192,8 @@ commander
 
     Logger.info(`👉 worker address for ${auxChainId} chain is `
       + `${facilitatorConfig.chains[auxChainId].worker}`);
+    Logger.info(`ℹ️ Run below two commands on terminal by replacing <origin password> and <auxiliary-password> with origin and auxiliary password entered in command`);
+    Logger.info(`1. export ${ENV_WORKER_PASSWORD_PREFIX + facilitatorConfig.chains[originChainId].worker}=<origin-password>`);
+    Logger.info(`2. export ${ENV_WORKER_PASSWORD_PREFIX + facilitatorConfig.chains[auxChainId].worker}=<auxiliary-password>`);
   })
   .parse(process.argv);


### PR DESCRIPTION
PR contains changes to  display worker keys to be exported on terminal in facilitator-init
fixes #237 