### PR TITLE
Message nonce consideration on message transfer

### DIFF
--- a/src/m1_facilitator/handlers/DeclaredDepositIntentsHandler.ts
+++ b/src/m1_facilitator/handlers/DeclaredDepositIntentsHandler.ts
@@ -36,6 +36,7 @@ interface DeclaredDepositIntentsEntityInterface {
   feeGasLimit: string;
   blockNumber: string;
   depositor: string;
+  nonce: string;
 }
 
 /**
@@ -99,6 +100,7 @@ export default class DeclaredDepositIntentsHandler extends ContractEntityHandler
           record.feeGasLimit,
           record.blockNumber,
           record.depositor,
+          record.nonce,
         );
         await this.handleDepositIntent(
           record.messageHash,
@@ -121,6 +123,7 @@ export default class DeclaredDepositIntentsHandler extends ContractEntityHandler
    * @param feeGasLimit GasLimit which depositor will be paying.
    * @param blockNumber Block number at which deposit transaction is mined.
    * @param depositor Address of depositor.
+   * @param nonce Mesasge nonce.
    */
   private async handleMessage(
     contractAddress: string,
@@ -129,6 +132,7 @@ export default class DeclaredDepositIntentsHandler extends ContractEntityHandler
     feeGasLimit: string,
     blockNumber: string,
     depositor: string,
+    nonce: string,
   ): Promise<void> {
     let messageObj = await this.messageRepository.get(messageHash);
     if (messageObj === null) {
@@ -148,6 +152,7 @@ export default class DeclaredDepositIntentsHandler extends ContractEntityHandler
           new BigNumber(blockNumber),
         );
         messageObj.sender = Utils.toChecksumAddress(depositor);
+        messageObj.nonce = new BigNumber(nonce);
         Logger.debug(`Creating message object ${JSON.stringify(messageObj)}`);
       } else {
         Logger.warn(`DeclaredDepositIntentsHandler::gateway record not found for gatewayGA ${contractAddress}`);

--- a/src/m1_facilitator/handlers/DeclaredWithdrawIntentsHandler.ts
+++ b/src/m1_facilitator/handlers/DeclaredWithdrawIntentsHandler.ts
@@ -37,6 +37,7 @@ interface DeclaredWithdrawIntentsEntityInterface {
   feeGasLimit: string;
   withdrawer: string;
   blockNumber: string;
+  nonce: string;
 }
 
 /**
@@ -112,6 +113,7 @@ export default class DeclaredWithdrawIntentsHandler extends ContractEntityHandle
           new BigNumber(record.feeGasLimit),
           Utils.toChecksumAddress(record.withdrawer),
           new BigNumber(record.blockNumber),
+          new BigNumber(record.nonce),
         );
         await this.handleWithdrawIntent(
           messageHash,
@@ -163,6 +165,7 @@ export default class DeclaredWithdrawIntentsHandler extends ContractEntityHandle
    * @param feeGasLimit Message transfer fee gas limit.
    * @param sender Address of message sender.
    * @param sourceDeclarationBlockNumber Block number at which this transaction is mined.
+   * @param nonce Message nonce.
    */
   private async handleMessage(
     messageHash: string,
@@ -171,6 +174,7 @@ export default class DeclaredWithdrawIntentsHandler extends ContractEntityHandle
     feeGasLimit: BigNumber,
     sender: string,
     sourceDeclarationBlockNumber: BigNumber,
+    nonce: BigNumber,
   ): Promise<void> {
     Logger.debug(`DeclaredWithdrawIntentsHandler::Getting message record for messageHash ${messageHash}`);
     let message = await this.messageRepository.get(messageHash);
@@ -188,6 +192,7 @@ export default class DeclaredWithdrawIntentsHandler extends ContractEntityHandle
       message.feeGasLimit = feeGasLimit;
       message.sender = Utils.toChecksumAddress(sender);
       message.sourceDeclarationBlockNumber = sourceDeclarationBlockNumber;
+      message.nonce = nonce;
     }
     message.sourceStatus = MessageStatus.Declared;
     await this.messageRepository.save(message);

--- a/src/m1_facilitator/models/Message.ts
+++ b/src/m1_facilitator/models/Message.ts
@@ -53,6 +53,8 @@ export default class Message extends Comparable<Message> {
 
   public sender?: string;
 
+  public nonce?: BigNumber;
+
   public createdAt?: Date;
 
   public updatedAt?: Date;
@@ -72,6 +74,7 @@ export default class Message extends Comparable<Message> {
    * @param sourceDeclarationBlockNumber Block number at which message was declared.
    * @param intentHash Intent hash.
    * @param sender Address of message sender.
+   * @param nonce Message nonce.
    * @param createdAt Time at which record is created.
    * @param updatedAt Time at which record is updated.
    */
@@ -86,6 +89,7 @@ export default class Message extends Comparable<Message> {
     sourceDeclarationBlockNumber?: BigNumber,
     intentHash?: string,
     sender?: string,
+    nonce?: BigNumber,
     createdAt?: Date,
     updatedAt?: Date,
   ) {
@@ -100,6 +104,7 @@ export default class Message extends Comparable<Message> {
     this.feeGasLimit = feeGasLimit;
     this.sourceDeclarationBlockNumber = sourceDeclarationBlockNumber;
     this.sender = sender;
+    this.nonce = nonce;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
   }

--- a/src/m1_facilitator/repositories/MessageRepository.ts
+++ b/src/m1_facilitator/repositories/MessageRepository.ts
@@ -46,6 +46,8 @@ class MessageModel extends Model {
 
   public readonly sender!: string;
 
+  public readonly nonce!: BigNumber;
+
   public readonly createdAt!: Date;
 
   public readonly updatedAt!: Date;
@@ -134,9 +136,12 @@ export default class MessageRepository extends Subject<Message> {
             min: 0,
           },
         },
-
         sender: {
           type: DataTypes.STRING,
+          allowNull: true,
+        },
+        nonce: {
+          type: DataTypes.BIGINT,
           allowNull: true,
         },
       },
@@ -311,6 +316,7 @@ export default class MessageRepository extends Subject<Message> {
         : messageModel.sourceDeclarationBlockNumber,
       messageModel.intentHash,
       messageModel.sender,
+      messageModel.nonce,
       messageModel.createdAt,
       messageModel.updatedAt,
     );

--- a/src/m1_facilitator/repositories/MessageRepository.ts
+++ b/src/m1_facilitator/repositories/MessageRepository.ts
@@ -316,7 +316,7 @@ export default class MessageRepository extends Subject<Message> {
         : messageModel.sourceDeclarationBlockNumber,
       messageModel.intentHash,
       messageModel.sender,
-      messageModel.nonce,
+      new BigNumber(messageModel.nonce),
       messageModel.createdAt,
       messageModel.updatedAt,
     );

--- a/src/m1_facilitator/repositories/MessageRepository.ts
+++ b/src/m1_facilitator/repositories/MessageRepository.ts
@@ -15,7 +15,7 @@
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
 import {
-  DataTypes, InitOptions, Model, Op,
+  DataTypes, InitOptions, Model, Op, literal,
 } from 'sequelize';
 import { MAX_VALUE } from '../../m0_facilitator/Constants';
 import Message, { MessageStatus, MessageType } from '../models/Message';
@@ -252,6 +252,9 @@ export default class MessageRepository extends Subject<Message> {
           type: messageType,
         },
       },
+      order: [
+        [literal('sender, nonce'), 'asc'],
+      ],
     });
 
     return messageModels.map(

--- a/test/m1_facilitator/handlers/ConfirmDepositIntentsHandler/handle.test.ts
+++ b/test/m1_facilitator/handlers/ConfirmDepositIntentsHandler/handle.test.ts
@@ -55,6 +55,8 @@ describe('ConfirmDepositIntentsHandler::handle', (): void => {
       '0x0000000000000000000000000000000000000001',
     );
 
+    existingMessage.nonce = new BigNumber(1);
+
     await messageRepository.save(existingMessage);
 
     const confirmDepositIntentRecord = {
@@ -120,6 +122,8 @@ describe('ConfirmDepositIntentsHandler::handle', (): void => {
       ),
     ];
 
+    existingMessages[0].nonce = new BigNumber(1);
+    existingMessages[1].nonce = new BigNumber(1);
     await messageRepository.save(existingMessages[0]);
     await messageRepository.save(existingMessages[1]);
 

--- a/test/m1_facilitator/handlers/ConfirmWithdrawIntentHandler/handle.test.ts
+++ b/test/m1_facilitator/handlers/ConfirmWithdrawIntentHandler/handle.test.ts
@@ -67,6 +67,8 @@ describe('ConfirmWithdrawIntentsHandler::handle', (): void => {
       '0x0000000000000000000000000000000000000001',
     );
 
+    existingMessage.nonce = new BigNumber(1);
+
     await messageRepository.save(existingMessage);
 
     const confirmWithdrawIntentRecord = {
@@ -141,6 +143,9 @@ describe('ConfirmWithdrawIntentsHandler::handle', (): void => {
       MessageStatus.Undeclared,
       '0x0000000000000000000000000000000000000002',
     );
+
+    existingMessage1.nonce = new BigNumber(1);
+    existingMessage2.nonce = new BigNumber(1);
 
     await messageRepository.save(existingMessage1);
     await messageRepository.save(existingMessage2);

--- a/test/m1_facilitator/handlers/DeclaredDepositIntentsHandler/handle.test.ts
+++ b/test/m1_facilitator/handlers/DeclaredDepositIntentsHandler/handle.test.ts
@@ -41,6 +41,7 @@ describe('DeclaredDepositIntentsHandler::handle', (): void => {
     feeGasPrice: '20',
     blockNumber: '100',
     depositor: '0x0000000000000000000000000000000000000070',
+    nonce: '1',
   };
   beforeEach(async (): Promise<void> => {
     repositories = await Repositories.create();
@@ -71,6 +72,7 @@ describe('DeclaredDepositIntentsHandler::handle', (): void => {
     feeGasPrice: string;
     blockNumber: string;
     depositor: string;
+    nonce: string;
   }): Promise<void> {
     const message = await messageRepository.get(record.messageHash);
 
@@ -119,6 +121,15 @@ describe('DeclaredDepositIntentsHandler::handle', (): void => {
         && message.sourceDeclarationBlockNumber && message.sourceDeclarationBlockNumber.toString(10)
       }`,
     );
+
+    assert.isOk(
+      message && message.nonce
+      && message.nonce.isEqualTo(
+        new BigNumber(record.nonce),
+      ),
+      `Expected nonce is ${record.nonce} but`
+      + ` found ${message && message.nonce && message.nonce.toString(10)}`,
+    );
   }
 
   async function assertDepositIntentRepository(record: {
@@ -160,18 +171,18 @@ describe('DeclaredDepositIntentsHandler::handle', (): void => {
 
   it('should change status of message from undeclared to declared for'
     + ' existing message', async (): Promise<void> => {
-    await messageRepository.save(
-      new Message(
-        record1.messageHash,
-        MessageType.Deposit,
-        MessageStatus.Undeclared,
-        MessageStatus.Undeclared,
-        '0x0000000000000000000000000000000000000050',
-        new BigNumber(20),
-        new BigNumber(20),
-        new BigNumber(100),
-      ),
+    const message = new Message(
+      record1.messageHash,
+      MessageType.Deposit,
+      MessageStatus.Undeclared,
+      MessageStatus.Undeclared,
+      '0x0000000000000000000000000000000000000050',
+      new BigNumber(20),
+      new BigNumber(20),
+      new BigNumber(100),
     );
+    message.nonce = new BigNumber(record1.nonce);
+    await messageRepository.save(message);
 
     await declaredDepositIntentsHandler.handle([record1]);
 
@@ -189,6 +200,7 @@ describe('DeclaredDepositIntentsHandler::handle', (): void => {
       beneficiary: '0x0000000000000000000000000000000000000070',
       amount: '20',
       depositor: '0x0000000000000000000000000000000000000070',
+      nonce: '1',
     };
 
     const gateway1 = new Gateway(
@@ -222,6 +234,7 @@ describe('DeclaredDepositIntentsHandler::handle', (): void => {
       beneficiary: '0x0000000000000000000000000000000000000070',
       amount: '20',
       depositor: '0x0000000000000000000000000000000000000070',
+      nonce: '1',
     };
 
     declaredDepositIntentsHandler = new DeclaredDepositIntentsHandler(

--- a/test/m1_facilitator/handlers/DeclaredWithdrawIntentsHandler/handle.test.ts
+++ b/test/m1_facilitator/handlers/DeclaredWithdrawIntentsHandler/handle.test.ts
@@ -55,6 +55,7 @@ describe('DeclaredWithdrawIntentsHandler::handle', (): void => {
       feeGasLimit: '2',
       withdrawer: '0x0000000000000000000000000000000000000005',
       blockNumber: '100',
+      nonce: '1',
     },
     {
       messageHash: web3Utils.sha3('2'),
@@ -66,13 +67,17 @@ describe('DeclaredWithdrawIntentsHandler::handle', (): void => {
       feeGasLimit: '2',
       withdrawer: '0x0000000000000000000000000000000000000005',
       blockNumber: '101',
+      nonce: '1',
     },
   ];
 
   beforeEach(async (): Promise<void> => {
     repositories = await Repositories.create();
     ({
-      messageRepository, withdrawIntentRepository, gatewayRepository, erc20GatewayTokenPairRepository,
+      messageRepository,
+      withdrawIntentRepository,
+      gatewayRepository,
+      erc20GatewayTokenPairRepository,
     } = repositories);
     handler = new DeclaredWithdrawIntentsHandler(
       repositories.withdrawIntentRepository,
@@ -223,6 +228,7 @@ describe('DeclaredWithdrawIntentsHandler::handle', (): void => {
       '0x0000000000000000000000000000000000000001',
     );
 
+    existingMessage.nonce = new BigNumber(1);
     await messageRepository.save(existingMessage);
 
     await handler.handle(withdrawIntentEntityRecords);
@@ -235,6 +241,12 @@ describe('DeclaredWithdrawIntentsHandler::handle', (): void => {
       messageRecord && messageRecord.sourceStatus,
       MessageStatus.Declared,
       'Message source status must be declared',
+    );
+
+    assert.isOk(
+      messageRecord && messageRecord.nonce
+      && messageRecord.nonce.isEqualTo(new BigNumber(withdrawIntentEntityRecords[0].nonce)),
+      `Nonce must match, expected nonce ${withdrawIntentEntityRecords[0].nonce} but found ${messageRecord && messageRecord.nonce} `,
     );
   });
 
@@ -250,6 +262,7 @@ describe('DeclaredWithdrawIntentsHandler::handle', (): void => {
         feeGasLimit: '2',
         withdrawer: '0x0000000000000000000000000000000000000005',
         blockNumber: '100',
+        nonce: '1',
       },
     ];
     const supportedTokens = new Set(['0x0000000000000000000000000000000000000022']);

--- a/test/m1_facilitator/repositories/MessageRepository/get.test.ts
+++ b/test/m1_facilitator/repositories/MessageRepository/get.test.ts
@@ -37,6 +37,7 @@ describe('MessageRepository::get', (): void => {
   let sender: string;
   let createdAt: Date;
   let updatedAt: Date;
+  let nonce: BigNumber;
 
   beforeEach(async (): Promise<void> => {
     config = {
@@ -52,6 +53,7 @@ describe('MessageRepository::get', (): void => {
     gatewayAddress = '0x0000000000000000000000000000000000000001';
     sourceDeclarationBlockNumber = new BigNumber(300);
     sender = '0x0000000000000000000000000000000000000005';
+    nonce = new BigNumber(0);
     createdAt = new Date();
     updatedAt = new Date();
 
@@ -66,6 +68,7 @@ describe('MessageRepository::get', (): void => {
       sourceDeclarationBlockNumber,
       intentHash,
       sender,
+      nonce,
       createdAt,
       updatedAt,
     );

--- a/test/m1_facilitator/repositories/MessageRepository/save.test.ts
+++ b/test/m1_facilitator/repositories/MessageRepository/save.test.ts
@@ -34,6 +34,7 @@ describe('MessageRepository::save', (): void => {
   let gatewayAddress: string;
   let sourceDeclarationBlockNumber: BigNumber;
   let sender: string;
+  let nonce: BigNumber;
   let createdAt: Date;
   let updatedAt: Date;
 
@@ -51,6 +52,7 @@ describe('MessageRepository::save', (): void => {
     gatewayAddress = '0x0000000000000000000000000000000000000001';
     sourceDeclarationBlockNumber = new BigNumber(300);
     sender = '0x0000000000000000000000000000000000000005';
+    nonce = new BigNumber(1);
     createdAt = new Date();
     updatedAt = new Date();
   });
@@ -67,6 +69,7 @@ describe('MessageRepository::save', (): void => {
       sourceDeclarationBlockNumber,
       intentHash,
       sender,
+      nonce,
       createdAt,
       updatedAt,
     );
@@ -89,6 +92,7 @@ describe('MessageRepository::save', (): void => {
       sourceDeclarationBlockNumber,
       intentHash,
       sender,
+      nonce,
       createdAt,
       updatedAt,
     );
@@ -121,6 +125,7 @@ describe('MessageRepository::save', (): void => {
       sourceDeclarationBlockNumber,
       intentHash,
       sender,
+      nonce,
       createdAt,
       updatedAt,
     );
@@ -143,6 +148,7 @@ describe('MessageRepository::save', (): void => {
       sourceDeclarationBlockNumber,
       intentHash,
       sender,
+      nonce,
       createdAt,
       updatedAt,
     );
@@ -168,6 +174,7 @@ describe('MessageRepository::save', (): void => {
       sourceDeclarationBlockNumber,
       intentHash,
       sender,
+      nonce,
       createdAt,
       updatedAt,
     );


### PR DESCRIPTION
fixes #360 

A single depositor can now submit multiple deposit requests. The gateway manages nonce for each request. Same nonce is manged by co-gateway.  The facilitator should submit confirm deposit request 