### PR TITLE
Anchor contract backward compatibility

### DIFF
--- a/src/m1_facilitator/SeedDataInitializer.ts
+++ b/src/m1_facilitator/SeedDataInitializer.ts
@@ -15,7 +15,7 @@
 import Web3 from 'web3';
 import Mosaic from 'Mosaic';
 import BigNumber from 'bignumber.js';
-import { interacts } from '@openst/mosaic-contracts';
+import { interacts as m0interacts } from '@openst/mosaic-contracts';
 
 import Anchor from './models/Anchor';
 import Gateway, { GatewayType } from './models/Gateway';
@@ -78,6 +78,7 @@ export default class SeedDataInitializer {
     let auxiliaryLatestAnchoredStateRootBlockHeight: string;
     let originLatestAnchoredStateRootBlockHeight: string;
     if (ArchitectureLayout.MOSAIC_0_14_GEN_1 === architectureLayout) {
+      Logger.debug('Getting anchor instance for Gen1');
       const originAnchorInstance = Mosaic.interacts.getAnchor(
         originWeb3,
         originAnchorAddress,
@@ -92,11 +93,12 @@ export default class SeedDataInitializer {
       originLatestAnchoredStateRootBlockHeight = await auxiliaryAnchorInstance.methods
         .getLatestStateRootBlockNumber().call();
     } else {
-      const originAnchorInstance = interacts.getAnchor(
+      Logger.debug('Getting anchor instance for Gen0');
+      const originAnchorInstance = m0interacts.getAnchor(
         originWeb3,
         originAnchorAddress,
       );
-      const auxiliaryAnchorInstance = interacts.getAnchor(
+      const auxiliaryAnchorInstance = m0interacts.getAnchor(
         auxiliaryWeb3,
         auxiliaryAnchorAddress,
       );

--- a/src/m1_facilitator/SeedDataInitializer.ts
+++ b/src/m1_facilitator/SeedDataInitializer.ts
@@ -77,7 +77,7 @@ export default class SeedDataInitializer {
     const auxiliaryAnchorAddress = await erc20Cogateway.methods.stateRootProvider().call();
     let auxiliaryLatestAnchoredStateRootBlockHeight: string;
     let originLatestAnchoredStateRootBlockHeight: string;
-    if (ArchitectureLayout.MOSAIC1_0_14 === architectureLayout) {
+    if (ArchitectureLayout.MOSAIC_0_14_GEN_1 === architectureLayout) {
       const originAnchorInstance = Mosaic.interacts.getAnchor(
         originWeb3,
         originAnchorAddress,

--- a/src/m1_facilitator/commands/FacilitatorInit.ts
+++ b/src/m1_facilitator/commands/FacilitatorInit.ts
@@ -87,6 +87,7 @@ export default class FacilitatorInit implements Command {
       originWeb3,
       auxiliaryWeb3,
       gatewayAddresses,
+      manifest.architectureLayout,
     );
   }
 }

--- a/src/m1_facilitator/manifest/Manifest.ts
+++ b/src/m1_facilitator/manifest/Manifest.ts
@@ -78,7 +78,10 @@ interface ManifestInfo {
 
 /** Enum of architecture layouts which facilitator supports. */
 export enum ArchitectureLayout {
-  MOSAIC1 = 'MOSAIC1',
+  // For supporting anchor contract in mosaic-1.
+  MOSAIC1_0_14 = 'MOSAIC1_0_14',
+  // For supporting backward compatibility of anchor contract on older chains like 1405.
+  MOSAIC1_0_10 = 'MOSAIC1_0_10',
 }
 
 /** Enum of different personas which facilitator supports. */

--- a/src/m1_facilitator/manifest/Manifest.ts
+++ b/src/m1_facilitator/manifest/Manifest.ts
@@ -78,10 +78,10 @@ interface ManifestInfo {
 
 /** Enum of architecture layouts which facilitator supports. */
 export enum ArchitectureLayout {
-  // For supporting anchor contract in mosaic-1.
-  MOSAIC_0_14_GEN_1 = 'MOSAIC_0_14_GEN_1',
   // For supporting backward compatibility of anchor contract on older chains like 1405.
   MOSAIC_0_14_GEN_0 = 'MOSAIC_0_14_GEN_0',
+  // For supporting anchor contract in mosaic-1.
+  MOSAIC_0_14_GEN_1 = 'MOSAIC_0_14_GEN_1',
 }
 
 /** Enum of different personas which facilitator supports. */

--- a/src/m1_facilitator/manifest/Manifest.ts
+++ b/src/m1_facilitator/manifest/Manifest.ts
@@ -79,9 +79,9 @@ interface ManifestInfo {
 /** Enum of architecture layouts which facilitator supports. */
 export enum ArchitectureLayout {
   // For supporting anchor contract in mosaic-1.
-  MOSAIC1_0_14 = 'MOSAIC1_0_14',
+  MOSAIC_0_14_GEN_1 = 'MOSAIC_0_14_GEN_1',
   // For supporting backward compatibility of anchor contract on older chains like 1405.
-  MOSAIC1_0_10 = 'MOSAIC1_0_10',
+  MOSAIC_0_14_GEN_0 = 'MOSAIC_0_14_GEN_0',
 }
 
 /** Enum of different personas which facilitator supports. */

--- a/src/m1_facilitator/manifest/manifest.schema.json
+++ b/src/m1_facilitator/manifest/manifest.schema.json
@@ -15,7 +15,7 @@
         "architecture_layout": {
           "type": "string",
           "additionalProperties": false,
-          "enum": ["MOSAIC1_0_14", "MOSAIC1_0_10"]
+          "enum": ["MOSAIC_0_14_GEN_0", "MOSAIC_0_14_GEN_1"]
         },
         "personas": {
           "type": "array",

--- a/src/m1_facilitator/manifest/manifest.schema.json
+++ b/src/m1_facilitator/manifest/manifest.schema.json
@@ -15,7 +15,7 @@
         "architecture_layout": {
           "type": "string",
           "additionalProperties": false,
-          "enum": ["MOSAIC1"]
+          "enum": ["MOSAIC1_0_14", "MOSAIC1_0_10"]
         },
         "personas": {
           "type": "array",

--- a/test/m1_facilitator/SeedDataInitializer/initialize.test.ts
+++ b/test/m1_facilitator/SeedDataInitializer/initialize.test.ts
@@ -188,7 +188,7 @@ describe('SeedDataInitializer:initialize', () => {
     },
   };
 
-  const fakeAnchor_0_10 = {
+  const fakeAnchor_Gen0 = {
     methods: {
       getLatestStateRootBlockHeight: () => ({
         call: async (): Promise<string> => Promise.resolve(latestAnchorBlockHeight),
@@ -229,7 +229,7 @@ describe('SeedDataInitializer:initialize', () => {
       originWeb3,
       auxiliaryWeb3,
       gatewayAddress,
-      ArchitectureLayout.MOSAIC1_0_14,
+      ArchitectureLayout.MOSAIC_0_14_GEN_1,
     );
 
     const gateway = await repositories.gatewayRepository.get(
@@ -275,7 +275,7 @@ describe('SeedDataInitializer:initialize', () => {
     );
   });
 
-  it('should initialize seed data when for supporting older testnet', async (): Promise<void> => {
+  it('should initialize seed data when facilitator is running on GEN0 testnet', async (): Promise<void> => {
     sinon.replace(
       Mosaic.interacts,
       'getERC20Gateway',
@@ -291,7 +291,7 @@ describe('SeedDataInitializer:initialize', () => {
     sinon.replace(
       interacts,
       'getAnchor',
-      sinon.fake.returns(fakeAnchor_0_10),
+      sinon.fake.returns(fakeAnchor_Gen0),
     );
 
     sinon.replace(
@@ -304,7 +304,7 @@ describe('SeedDataInitializer:initialize', () => {
       originWeb3,
       auxiliaryWeb3,
       gatewayAddress,
-      ArchitectureLayout.MOSAIC1_0_10,
+      ArchitectureLayout.MOSAIC_0_14_GEN_0,
     );
 
     const gateway = await repositories.gatewayRepository.get(

--- a/test/m1_facilitator/SeedDataInitializer/initialize.test.ts
+++ b/test/m1_facilitator/SeedDataInitializer/initialize.test.ts
@@ -273,7 +273,6 @@ describe('SeedDataInitializer:initialize', () => {
       originAnchorAddress,
       auxiliaryAnchorAddress,
     );
-    sinon.restore();
   });
 
   it('should initialize seed data when for supporting older testnet', async (): Promise<void> => {
@@ -351,5 +350,7 @@ describe('SeedDataInitializer:initialize', () => {
     );
   });
 
-  sinon.restore();
+  afterEach(async (): Promise<void> => {
+    sinon.restore();
+  });
 });

--- a/test/m1_facilitator/commands/FacilitatorInit/execute.test.ts
+++ b/test/m1_facilitator/commands/FacilitatorInit/execute.test.ts
@@ -46,7 +46,7 @@ describe('FacilitatorInit.execute', (): void => {
   it('should execute facilitator init', async (): Promise<void> => {
     await facilitatorInit.execute();
 
-    SpyAssert.assert(directorySpy, 1, [['MOSAIC1_0_14', '0xA7f056b1320fE619571849f138Cd1Ae2f2e64179']]);
+    SpyAssert.assert(directorySpy, 1, [['MOSAIC_0_14_GEN_1', '0xA7f056b1320fE619571849f138Cd1Ae2f2e64179']]);
     SpyAssert.assertCall(initializeSpy, 1);
   });
 

--- a/test/m1_facilitator/commands/FacilitatorInit/execute.test.ts
+++ b/test/m1_facilitator/commands/FacilitatorInit/execute.test.ts
@@ -46,7 +46,7 @@ describe('FacilitatorInit.execute', (): void => {
   it('should execute facilitator init', async (): Promise<void> => {
     await facilitatorInit.execute();
 
-    SpyAssert.assert(directorySpy, 1, [['MOSAIC1', '0xA7f056b1320fE619571849f138Cd1Ae2f2e64179']]);
+    SpyAssert.assert(directorySpy, 1, [['MOSAIC1_0_14', '0xA7f056b1320fE619571849f138Cd1Ae2f2e64179']]);
     SpyAssert.assertCall(initializeSpy, 1);
   });
 

--- a/test/m1_facilitator/manifest/fromFile.test.ts
+++ b/test/m1_facilitator/manifest/fromFile.test.ts
@@ -98,7 +98,7 @@ describe('Config.fromFile()', (): void => {
 
     const dbConfig = new DBConfig();
     dbConfig.path = Directory.getFacilitatorDatabaseFile(
-      ArchitectureLayout.MOSAIC1_0_14,
+      ArchitectureLayout.MOSAIC_0_14_GEN_1,
       inputYamlConfig.origin_contract_addresses.erc20_gateway,
     );
     assert.deepStrictEqual(

--- a/test/m1_facilitator/manifest/fromFile.test.ts
+++ b/test/m1_facilitator/manifest/fromFile.test.ts
@@ -98,7 +98,7 @@ describe('Config.fromFile()', (): void => {
 
     const dbConfig = new DBConfig();
     dbConfig.path = Directory.getFacilitatorDatabaseFile(
-      ArchitectureLayout.MOSAIC1,
+      ArchitectureLayout.MOSAIC1_0_14,
       inputYamlConfig.origin_contract_addresses.erc20_gateway,
     );
     assert.deepStrictEqual(

--- a/test_integration/m1_facilitator/03_facilitator_init/FacilitatorManifestGenerator.ts
+++ b/test_integration/m1_facilitator/03_facilitator_init/FacilitatorManifestGenerator.ts
@@ -22,7 +22,7 @@ import { Shared } from '../shared';
 
 const generateFacilitatorManifest = (shared: Shared) => ({
   version: 'v0.14',
-  architecture_layout: ArchitectureLayout.MOSAIC1,
+  architecture_layout: ArchitectureLayout.MOSAIC1_0_14,
   personas: [Personas.FACILITATOR],
   metachain:
     {

--- a/test_integration/m1_facilitator/03_facilitator_init/FacilitatorManifestGenerator.ts
+++ b/test_integration/m1_facilitator/03_facilitator_init/FacilitatorManifestGenerator.ts
@@ -22,7 +22,7 @@ import { Shared } from '../shared';
 
 const generateFacilitatorManifest = (shared: Shared) => ({
   version: 'v0.14',
-  architecture_layout: ArchitectureLayout.MOSAIC1_0_14,
+  architecture_layout: ArchitectureLayout.MOSAIC_0_14_GEN_1,
   personas: [Personas.FACILITATOR],
   metachain:
     {

--- a/test_integration/m1_facilitator/05_deposit/01_deposit.test.ts
+++ b/test_integration/m1_facilitator/05_deposit/01_deposit.test.ts
@@ -90,7 +90,7 @@ describe('Deposit token ', () => {
   it('Assert balances', async (): Promise<void> => {
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1,
+        ArchitectureLayout.MOSAIC1_0_14,
         shared.contracts.erc20Gateway.address,
       ),
     );
@@ -128,7 +128,7 @@ describe('Deposit token ', () => {
     const gatewayAddresses = shared.contracts.erc20Gateway.address;
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1,
+        ArchitectureLayout.MOSAIC1_0_14,
         gatewayAddresses,
       ),
     );

--- a/test_integration/m1_facilitator/05_deposit/01_deposit.test.ts
+++ b/test_integration/m1_facilitator/05_deposit/01_deposit.test.ts
@@ -90,7 +90,7 @@ describe('Deposit token ', () => {
   it('Assert balances', async (): Promise<void> => {
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1_0_14,
+        ArchitectureLayout.MOSAIC_0_14_GEN_1,
         shared.contracts.erc20Gateway.address,
       ),
     );
@@ -128,7 +128,7 @@ describe('Deposit token ', () => {
     const gatewayAddresses = shared.contracts.erc20Gateway.address;
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1_0_14,
+        ArchitectureLayout.MOSAIC_0_14_GEN_1,
         gatewayAddresses,
       ),
     );

--- a/test_integration/m1_facilitator/06_withdraw/01_withdraw.test.ts
+++ b/test_integration/m1_facilitator/06_withdraw/01_withdraw.test.ts
@@ -90,7 +90,7 @@ describe('withdraw', async (): Promise<void> => {
   it('Balance assertion of withdrawer', async (): Promise<void> => {
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1_0_14,
+        ArchitectureLayout.MOSAIC_0_14_GEN_1,
         shared.contracts.erc20Gateway.address,
       ),
     );
@@ -122,7 +122,7 @@ describe('withdraw', async (): Promise<void> => {
     const gatewayAddresses = shared.contracts.erc20Gateway.address;
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1_0_14,
+        ArchitectureLayout.MOSAIC_0_14_GEN_1,
         gatewayAddresses,
       ),
     );

--- a/test_integration/m1_facilitator/06_withdraw/01_withdraw.test.ts
+++ b/test_integration/m1_facilitator/06_withdraw/01_withdraw.test.ts
@@ -90,7 +90,7 @@ describe('withdraw', async (): Promise<void> => {
   it('Balance assertion of withdrawer', async (): Promise<void> => {
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1,
+        ArchitectureLayout.MOSAIC1_0_14,
         shared.contracts.erc20Gateway.address,
       ),
     );
@@ -122,7 +122,7 @@ describe('withdraw', async (): Promise<void> => {
     const gatewayAddresses = shared.contracts.erc20Gateway.address;
     const repositories = await Repositories.create(
       Directory.getFacilitatorDatabaseFile(
-        ArchitectureLayout.MOSAIC1,
+        ArchitectureLayout.MOSAIC1_0_14,
         gatewayAddresses,
       ),
     );

--- a/testdata/m1_facilitator/facilitator_manifest.yml
+++ b/testdata/m1_facilitator/facilitator_manifest.yml
@@ -1,5 +1,5 @@
 version: v0.14
-architecture_layout: MOSAIC1
+architecture_layout: MOSAIC1_0_14
 personas:
   - facilitator
 metachain:

--- a/testdata/m1_facilitator/facilitator_manifest.yml
+++ b/testdata/m1_facilitator/facilitator_manifest.yml
@@ -1,5 +1,5 @@
 version: v0.14
-architecture_layout: MOSAIC1_0_14
+architecture_layout: MOSAIC_0_14_GEN_1
 personas:
   - facilitator
 metachain:


### PR DESCRIPTION
PR contains below changes:
1. Making backward compatibility for anchor contract. If the `architecture_layout` value is `MOSAIC_0_14_GEN_1` then chain has Anchor contract of Mosaic-1. If the value for `architecture_ layout` is `MOSAIC_0_14_GEN_0` then the chain has Anchor contract of Mosaic-0 i.e. mosaic-contract-0.10 published npm version.
2. Updated unit test case.

fixes #357 